### PR TITLE
Fix build error introduced in 89acaacad91cb0fb0d9f

### DIFF
--- a/env-builder-data/build/script/packet/synfigstudio-nsis.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-nsis.sh
@@ -77,7 +77,7 @@ pkinstall_release() {
             sox.exe \
             synfig.exe \
             synfigstudio.exe; do
-        cp -rf "$ENVDEPS_RELEASE_PACKET_DIR/bin/${FILE}" "./bin/" || return 1
+        cp -rf "$ENVDEPS_RELEASE_PACKET_DIR/bin/"${FILE} "./bin/" || return 1
     done
     copy "$ENVDEPS_RELEASE_PACKET_DIR/etc/" "./etc/" || return 1
     [ -d "./lib/gdk-pixbuf-2.0/2.10.0/loaders" ] || mkdir -p "./lib/gdk-pixbuf-2.0/2.10.0/loaders"

--- a/env-builder-data/build/script/packet/synfigstudio-portable.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-portable.sh
@@ -43,7 +43,7 @@ pkinstall_release() {
             sox.exe \
             synfig.exe \
             synfigstudio.exe; do
-        cp -rf "$ENVDEPS_RELEASE_PACKET_DIR/bin/${FILE}" "./bin/" || return 1
+        cp -rf "$ENVDEPS_RELEASE_PACKET_DIR/bin/"${FILE} "./bin/" || return 1
     done
     copy "$ENVDEPS_RELEASE_PACKET_DIR/etc/" "./etc/" || return 1
     [ -d "./lib/gdk-pixbuf-2.0/2.10.0/loaders" ] || mkdir -p "./lib/gdk-pixbuf-2.0/2.10.0/loaders"


### PR DESCRIPTION
Builder gives an error:
```
cp: cannot stat `/build/packet/win-64/synfigstudio-nsis/envdeps_release/bin/gspawn-win*-helper-*': No such file or directory
```