### PR TITLE
Synfig Appimage: Add fallback options to display warning about Fontconfig cache generation

### DIFF
--- a/env-builder-data/build/script/packet/synfigstudio-appimage.files/fontconfig-warning.tcl
+++ b/env-builder-data/build/script/packet/synfigstudio-appimage.files/fontconfig-warning.tcl
@@ -1,0 +1,6 @@
+wm geometry . 400x50
+wm title . "Fontconfig"
+frame .fr
+pack .fr -fill both -expand 1
+label .fr.label -text "Please wait, generating font cache..."
+pack .fr.label -pady 10

--- a/env-builder-data/build/script/packet/synfigstudio-appimage.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-appimage.sh
@@ -18,6 +18,7 @@ pkinstall() {
     cp --remove-destination "$FILES_PACKET_DIR/synfigstudio.desktop" "$APPDIR/" || return 1
     cp --remove-destination "$FILES_PACKET_DIR/synfigstudio.png" "$APPDIR/" || return 1
     cp --remove-destination "$FILES_PACKET_DIR/launch.sh" "$APPDIR/usr/bin/" || return 1
+    cp --remove-destination "$FILES_PACKET_DIR/fontconfig-warning.tcl" "$APPDIR/usr/bin/" || return 1
 }
 
 pkinstall_release() {


### PR DESCRIPTION
Now we support Zenity, KDialog, Tcl/Tk, xmessage.