### PR TITLE
Synfig: Fontconfig now uses system's configuration

### DIFF
--- a/env-builder-data/build/script/packet/synfigstudio-appimage.files/launch.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-appimage.files/launch.sh
@@ -19,7 +19,7 @@ export XDG_CONFIG_DIRS="$HOME/.config/synfig:$XDG_CONFIG_DIRS"
 export XCURSOR_PATH="${BASE_DIR}/share/icons:$XCURSOR_PATH:/usr/local/share/icons:/usr/share/icons"
 export GSETTINGS_SCHEMA_DIR="${BASE_DIR}/share/glib-2.0/schemas/"
 export QT_XKB_CONFIG_ROOT=$QT_XKB_CONFIG_ROOT:/usr/local/share/X11/xkb:/usr/share/X11/xkb
-export FONTCONFIG_PATH="${BASE_DIR}/etc/fonts"
+export FONTCONFIG_PATH="/etc/fonts"
 
 export SYNFIG_ROOT="${BASE_DIR}"
 export SYNFIG_GTK_THEME="Adwaita"


### PR DESCRIPTION
This  should eliminate the need to generate cache on fresh systems when we will get fontconfig updated.