### PR TITLE
Synfig: Fix issue with missing gspawn-win64-helper.exe binary.

### DIFF
--- a/env-builder-data/build/script/packet/synfigstudio-nsis.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-nsis.sh
@@ -72,7 +72,7 @@ pkinstall_release() {
             gdk-pixbuf-pixdata.exe \
             gdk-pixbuf-query-loaders.exe \
             gio-querymodules.exe \
-            gspawn-win*-helper-* \
+            gspawn-win*-helper* \
             melt.exe \
             sox.exe \
             synfig.exe \


### PR DESCRIPTION
Fixes https://github.com/synfig/synfig/issues/2393.