### PR TITLE
Fix zlib dependency for NSIS

### DIFF
--- a/build-synfigstudio.sh
+++ b/build-synfigstudio.sh
@@ -49,7 +49,6 @@ run_nsis() {
     echo ""
     echo "Update and build synfigstudio for $PLATFORM-$ARCH"
     echo ""
-    PLATFORM=win ARCH=32 $SCRIPT clean_before_do env zlib-1.2.11 # for NSIS
     $SCRIPT chain native update synfigetl-master \
             chain native update synfigcore-master \
             chain update synfigetl-master \

--- a/env-builder-data/build/script/packet/nsis-3.08.sh
+++ b/env-builder-data/build/script/packet/nsis-3.08.sh
@@ -6,15 +6,16 @@ PK_ARCHIVE="$PK_DIRNAME.tar.bz2"
 PK_URL="http://prdownloads.sourceforge.net/nsis/$PK_ARCHIVE"
 
 #TODO: hardcoded path to mingw binaries
-#TODO: untracked dependency for zlib win32
-
 PK_PATH="/usr/i686-w64-mingw32/bin/:$PATH"
-PK_ZLIB_W32="$PACKET_BUILD_DIR/win-32/zlib-1.2.11/env"
+PK_ZLIB_W32="$PACKET_BUILD_DIR/win-32/zlib-1.2.11/install"
 PK_NSIS_MAX_STRLEN=131072
 
 source $INCLUDE_SCRIPT_DIR/inc-pkall-default.sh
 
 pkbuild() {
+    
+    PLATFORM=win ARCH=32 /build/script/common/manager.sh install_release zlib-1.2.11
+    
     cd "$BUILD_PACKET_DIR/$PK_DIRNAME" || return 1
     PATH="$PK_PATH" scons \
         PREFIX="$INSTALL_PACKET_DIR" \

--- a/env-builder-data/build/script/packet/zlib-1.2.11.sh
+++ b/env-builder-data/build/script/packet/zlib-1.2.11.sh
@@ -13,6 +13,9 @@ if [ "$PLATFORM" = "win" ]; then
 pkbuild() {
     cd "$BUILD_PACKET_DIR/$PK_DIRNAME" || return 1
     cp "$FILES_PACKET_DIR/Makefile.mingw" .
+    if [[ $PLATFORM == "win" ]] && [[ $ARCH == "32" ]]; then
+        sed -i 's|x86_64-w64-mingw32|i686-w64-mingw32|g'  Makefile.mingw
+    fi
     make -fMakefile.mingw SHARED_MODE=1 -j${THREADS} || return 1
 }
 pkinstall() {


### PR DESCRIPTION
This is a better approach how to handle requirement of 32bit win binary of zlib for NSIS (when compiled on linux).