### PR TITLE
Fix missing gspawn-win64-helper.exe (portable)

### DIFF
--- a/env-builder-data/build/script/packet/synfigstudio-master-portable.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-master-portable.sh
@@ -62,7 +62,7 @@ pkinstall_release() {
             gdk-pixbuf-pixdata.exe \
             gdk-pixbuf-query-loaders.exe \
             gio-querymodules.exe \
-            gspawn-win*-helper-* \
+            gspawn-win*-helper* \
             melt.exe \
             sox.exe \
             synfig.exe \


### PR DESCRIPTION
Similar to "Synfig: Fix issue with missing gspawn-win64-helper.exe binary" applied to portable version
https://github.com/morevnaproject/morevna-builds/commit/bddac6428cb369140b385ee6ec86d4a88c0f34fc