### PR TITLE
Do not use "-fcommon" flag globally for MinGW environment

### DIFF
--- a/env-builder-data/build/script/packet/gtk-3.22.30.sh
+++ b/env-builder-data/build/script/packet/gtk-3.22.30.sh
@@ -15,6 +15,8 @@ source $INCLUDE_SCRIPT_DIR/inc-pkall-default.sh
 
 if [ "$PLATFORM" = "win" ]; then
     PK_CONFIGURE_OPTIONS="--enable-introspection=no"
+    PK_CFLAGS="-fcommon"
+    PK_CPPFLAGS="-fcommon"
 fi
 
 pkhook_prebuild() {

--- a/env-builder-data/build/script/toolchain/win-common.sh
+++ b/env-builder-data/build/script/toolchain/win-common.sh
@@ -24,7 +24,7 @@ export WINEPATH="$WINEPATH_BASE"
 #                       - may be better, but work fine without it, will added when any problem raised
 #
 # So no extra options for now
-export TC_EXTRA_CPP_OPTIONS="-fcommon"
+export TC_EXTRA_CPP_OPTIONS=""
 export TC_CFLAGS=" $TC_EXTRA_CPP_OPTIONS $INITIAL_CFLAGS"
 export TC_CPPFLAGS=" $TC_EXTRA_CPP_OPTIONS $INITIAL_CPPFLAGS"
 export TC_CXXFLAGS=" $TC_EXTRA_CPP_OPTIONS $INITIAL_CXXFLAGS"


### PR DESCRIPTION
It is needed by gtk-3.22.30 only.