### PR TITLE
Fix missing "magick++" module in Synfig (Windows)

### DIFF
--- a/env-builder-data/build/script/packet/synfigstudio-master.sh
+++ b/env-builder-data/build/script/packet/synfigstudio-master.sh
@@ -91,6 +91,7 @@ pkinstall() {
         cp "$LOCAL_DIR"/libstdc*.dll       "$TARGET" || return 1
         cp "$LOCAL_DIR"/libquadmath*.dll   "$TARGET" || return 1
         cp "$LOCAL_DIR"/libgfortran*.dll   "$TARGET" || return 1
+        cp "$LOCAL_DIR"/libgomp*.dll       "$TARGET" || return 1
 
         #local LOCAL_DIR="/usr/local/$HOST/sys-root/bin/"
         local LOCAL_DIR="/usr/$HOST/lib/"


### PR DESCRIPTION
That's because Synfig 1.4.4 has missing library -
![WhatsApp Image 2023-02-03 at 15 57 33](https://user-images.githubusercontent.com/332868/216558511-55d3d578-68b6-4363-aca4-113cd40ae6b8.jpeg)
