### PR TITLE
build: bump target Windows version for synfig-core

### DIFF
--- a/env-builder-data/build/script/packet/synfigcore-master.sh
+++ b/env-builder-data/build/script/packet/synfigcore-master.sh
@@ -73,6 +73,7 @@ PK_DIRNAME="synfig"
 PK_URL="https://github.com/synfig/$PK_DIRNAME.git"
 PK_GIT_CHECKOUT="origin/testing"
 PK_LICENSE_FILES="synfig-core/AUTHORS synfig-core/README"
+PK_CPPFLAGS="-DWINVER=0x0600" # required for `GetUserDefaultLocaleName` function
 
 source $INCLUDE_SCRIPT_DIR/inc-pkall-git.sh
 


### PR DESCRIPTION
Currently build fails with the following error because `GetUserDefaultLocaleName` is available since Windows Vista (WINVER=0x0600). https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getuserdefaultlocalename

So I raised the target Windows version for Synfig.

```
os.cpp: In function 'const std::vector<std::__cxx11::basic_string<char> >& synfig::OS::get_user_lang()':
os.cpp:810:11: error: 'GetUserDefaultLocaleName' was not declared in this scope; did you mean 'GetUserDefaultUILanguage'?
  810 |  if (0 != GetUserDefaultLocaleName(lpLocaleName, LOCALE_NAME_MAX_LENGTH)) {
      |           ^~~~~~~~~~~~~~~~~~~~~~~~
      |           GetUserDefaultUILanguage
``