### PR TITLE
Update imagemagick-6.8.7.sh

### DIFF
--- a/env-builder-data/build/script/packet/imagemagick-6.8.7.sh
+++ b/env-builder-data/build/script/packet/imagemagick-6.8.7.sh
@@ -2,7 +2,7 @@ DEPS="jpeg-9b png-1.6.26 tiff-4.0.6 xml-2.9.4 fftw-3.3.5"
 
 PK_DIRNAME="ImageMagick-6.8.7-10"
 PK_ARCHIVE="$PK_DIRNAME.tar.xz"
-PK_URL="http://www.imagemagick.org/download/releases/$PK_ARCHIVE"
+PK_URL="https://imagemagick.org/archive/releases/$PK_ARCHIVE"
 
 PK_CONFIGURE_OPTIONS=" \
  --without-perl \


### PR DESCRIPTION
The archive is now located at https://imagemagick.org/archive/releases/ImageMagick-6.8.7-10.tar.xz

Issue https://github.com/morevnaproject/morevna-builds/issues/139