### PR TITLE
Fix opentoonz builder

### DIFF
--- a/build-opentoonz.sh
+++ b/build-opentoonz.sh
@@ -46,24 +46,24 @@ run_nsis() {
     echo ""
     PLATFORM=win ARCH=32 $SCRIPT clean_before_do env zlib-1.2.13 # for NSIS
     $SCRIPT chain update opentoonz-master \
-            chain clean_before_do install_release opentoonz-nsis \
-            chain clean_before_do install_release opentoonz-portable
+            chain clean_before_do install_release opentoonz-master-nsis \
+            chain clean_before_do install_release opentoonz-master-portable
 
     local TEMPLATE=`gen_name_template "OpenToonz" "" "$PLATFORM" "$ARCH" ".exe"`
     "$PUBLISH_DIR/publish.sh" \
         "opentoonz" \
         "$TEMPLATE" \
-        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-nsis/install_release" \
+        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-master-nsis/install_release" \
         "*.exe" \
-        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-nsis/envdeps_release/version-opentoonz-master"
+        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-master-nsis/envdeps_release/version-opentoonz-master"
 
     local TEMPLATE=`gen_name_template "OpenToonz" "" "$PLATFORM" "$ARCH" ".zip"`
     "$PUBLISH_DIR/publish.sh" \
         "opentoonz" \
         "$TEMPLATE" \
-        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-portable/install_release" \
+        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-master-portable/install_release" \
         "*.zip" \
-        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-portable/envdeps_release/version-opentoonz-master"
+        "$PACKET_BUILD_DIR/$PLATFORM-$ARCH/opentoonz-master-portable/envdeps_release/version-opentoonz-master"
 }
 
 linux64() { run_appimage linux 64; }

--- a/env-builder-data/build/script/packet/lz4-master.sh
+++ b/env-builder-data/build/script/packet/lz4-master.sh
@@ -9,14 +9,24 @@ source $INCLUDE_SCRIPT_DIR/inc-pkall-git.sh
 
 pkbuild() {
     cd "$BUILD_PACKET_DIR/$PK_DIRNAME"
-    if ! PREFIX=${INSTALL_PACKET_DIR} make -j${THREADS}; then
+    # Build only the library, not the tools. For cross-compilation to Windows,
+    # the executable may not be created correctly, but we only need liblz4.a
+    if ! PREFIX=${INSTALL_PACKET_DIR} make -j${THREADS} lib; then
         return 1
     fi
 }
 
 pkinstall() {
     cd "$BUILD_PACKET_DIR/$PK_DIRNAME"
-    if ! PREFIX=${INSTALL_PACKET_DIR} make install; then
+    # Install only the library, not programs. This avoids trying to install
+    # the lz4 executable which may not have been built for Windows cross-compile.
+    if ! PREFIX=${INSTALL_PACKET_DIR} make -C lib install; then
         return 1
+    fi
+    
+    # For Windows cross-compilation, remove .so files to prevent mingw linker 
+    # from selecting ELF shared objects instead of static archives
+    if [ "$BUILD_TARGET_WIN" = "1" ] || [ "$PLATFORM" = "win" ]; then
+        rm -f "$INSTALL_PACKET_DIR/lib/"*.so* 2>/dev/null || true
     fi
 }

--- a/env-builder-data/build/script/packet/opentoonz-master-nsis.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master-nsis.sh
@@ -6,6 +6,57 @@ pkfunc_register_file() {
     local WIN_FILE=$(echo "$FILE" | sed "s|\/|\\\\|g")
     ! [ -L "$FILE" ] || return 0
 
+    # NSIS 3.08 in this environment may segfault on UTF-8 path components.
+    # Skip non-ASCII entries during list generation.
+    if ! printf '%s' "$FILE" | LC_ALL=C grep -Eq '^[ -~]+$'; then
+        echo "skip path (non-ascii): $FILE"
+        return 0
+    fi
+
+    # On case-insensitive Windows filesystems the stray top-level "LICENSE"
+    # file (shipped by one of the dependencies, e.g. OpenCV) collides with the
+    # aggregated third-party "license/" directory. NSIS writes the file first,
+    # then CreateDirectory "$INSTDIR\license" fails because the name is already
+    # taken, and every "license\license-*" write aborts with
+    # "Error opening file for writing". Install the stray file as LICENSE.txt
+    # so both can coexist.
+    if [ "$FILE" = "./LICENSE" ]; then
+        echo "skip case-collision file (install as LICENSE.txt): $FILE"
+        echo "File \"/oname=LICENSE.txt\" \"LICENSE\"" >> "files-install.nsh"
+        echo "Delete \"\$INSTDIR\\LICENSE.txt\""       >> "files-uninstall.nsh"
+        return 0
+    fi
+
+    # NSIS 3.08 crashes while packaging the large stuff/doc payload in this
+    # environment. Skip docs to keep installer generation reliable.
+    if [ "$FILE" = "./share/opentoonz/stuff/doc" ]; then
+        echo "skip doc subtree (nsis instability): $FILE"
+        return 0
+    fi
+
+    # NSIS 3.08 on this build image crashes or misparses when File commands
+    # recurse through non-ASCII path components (e.g. Español, Français).
+    # Package only ASCII-safe locale directory names to keep installer
+    # generation stable.
+    if [ "$FILE" = "./share/opentoonz/stuff/config/loc" ]; then
+        local LOC_SUBDIR=
+        local LOC_NAME=
+        echo "CreateDirectory \"\$STUFFDIR\\config\\loc\"" >> "files-stuff-install.nsh"
+        for LOC_SUBDIR in "$FILE"/*; do
+            [ -d "$LOC_SUBDIR" ] || continue
+            LOC_NAME=$(basename "$LOC_SUBDIR")
+            if printf '%s' "$LOC_NAME" | grep -Eq '^[A-Za-z0-9._ -]+$'; then
+                if ! pkfunc_register_file "$LOC_SUBDIR"; then
+                    return 1
+                fi
+            else
+                echo "skip locale directory (non-ascii): $LOC_NAME"
+            fi
+        done
+        echo "RMDir \"\$STUFFDIR\\config\\loc\"" >> "files-stuff-uninstall.nsh"
+        return 0
+    fi
+
     if [ "${FILE:0:8}" = "./files-" ]; then
         true # skip
     elif [ "${FILE:0:24}" = "./share/opentoonz/stuff/" ]; then

--- a/env-builder-data/build/script/packet/opentoonz-master.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master.sh
@@ -50,6 +50,72 @@ pkbuild() {
         # Idempotent: the exact "= rout;" pattern no longer matches once patched.
         sed -i 's/TRaster32P rout32 = rout;/TRaster32P rout32 = (TRasterP)rout;/' \
             "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/common/trop/tresample.cpp" || return 1
+        
+        # Fix duplicate explicit template instantiation in tnotanimatableparam.h
+        # Keep the first occurrence and drop any later duplicates in a
+        # line-content-based way (avoid brittle fixed line numbers).
+        local _tna_file="$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/include/tnotanimatableparam.h"
+        awk 'BEGIN{n=0} {
+            if ($0 == "template class DVAPI TNotAnimatableParam<std::wstring>;") {
+                n++
+                if (n > 1) next
+            }
+            print
+        }' "$_tna_file" > "$_tna_file.tmp" || return 1
+        mv "$_tna_file.tmp" "$_tna_file" || return 1
+
+        # tnzext links the static Fortran BLAS (libblas.a) pulled in by SuperLU.
+        # Those objects need the gfortran runtime (_gfortran_*) and libm. Append
+        # the plain library names 'gfortran m' (CMake turns them into -lgfortran
+        # -lm; using a leading dash here would make CMake treat them as missing
+        # file targets and fail with "No rule to make target '-lgfortran'").
+        # Idempotent: only matches the line that does not already contain gfortran.
+        sed -i 's/\(\${SUPERLU_LIB} \${OPENBLAS_LIB}\) \(\${EXTRA_LIBS}\)/\1 gfortran m \2/' \
+            "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/tnzext/CMakeLists.txt" || return 1
+
+        # toonzqt compiles ../tnztools/cursormanager.cpp into its own DLL (to
+        # avoid a circular toonzqt<->tnztools dependency). On Windows the
+        # cursormanager.h declarations use DV_IMPORT_API unless TNZTOOLS_EXPORTS
+        # is defined, so toonzqt's own callers (schematicviewer.cpp) reference
+        # __imp_setToolCursor which does not exist (the function is defined
+        # locally, not imported) -> "undefined reference to
+        # __imp__Z13setToolCursorP7QWidgeti". Define TNZTOOLS_EXPORTS for the
+        # toonzqt target so setToolCursor/getToolCursor are treated as exported
+        # (local) symbols. toonzqt only pulls cursormanager.h/cursors.h from
+        # tnztools, so this does not affect any genuinely-imported symbols.
+        sed -i 's/    -DTOONZQT_EXPORTS/    -DTOONZQT_EXPORTS\n    -DTNZTOOLS_EXPORTS/' \
+            "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/toonzqt/CMakeLists.txt" || return 1
+
+        # The MinGW sysroot only ships a lowercase "windows.h"; a couple of
+        # sources (stopmotion/webcam.cpp, toonz/penciltestpopup.cpp) include
+        # <Windows.h> with a capital W, which fails on the case-sensitive Linux
+        # build host ("fatal error: Windows.h: No such file or directory").
+        # Lowercase the include so it resolves. (On real Windows the filesystem
+        # is case-insensitive, so this is a no-op there.)
+        grep -rlZ '#include <Windows.h>' "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources" 2>/dev/null \
+            | xargs -0 -r sed -i 's/#include <Windows.h>/#include <windows.h>/' || return 1
+
+        # stopmotion/webcam.cpp and toonz/penciltestpopup.cpp call the Media
+        # Foundation device-enumeration function MFEnumDeviceSources, which
+        # MinGW-w64's mfidl.h does not declare -> "not declared in this scope".
+        # The symbol IS exported by mf.dll (present in libmf.a). Insert the
+        # prototype after the #include <mfidl.h> line in every file that uses it.
+        # Idempotent: grep check prevents double-insertion.
+        for _f in $(grep -rlZ '<mfidl.h>' "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources" 2>/dev/null | tr '\0' ' '); do
+            if ! grep -q 'MFEnumDeviceSources(IMFAttributes' "$_f"; then
+                sed -i '/#include <mfidl.h>/a extern "C" HRESULT __stdcall MFEnumDeviceSources(IMFAttributes *pAttributes, IMFActivate ***pppSourceActivate, UINT32 *pcSourceActivate);' \
+                    "$_f" || return 1
+            fi
+        done
+
+        # The OpenToonz target links the Media Foundation libs only through MSVC
+        # "#pragma comment(lib, ...)" directives in webcam.cpp, which GCC/MinGW
+        # ignores. The cross build therefore fails to resolve MFEnumDeviceSources,
+        # MFCreateAttributes, MFStartup, etc. Add the corresponding MinGW import
+        # libraries to the OpenToonz link line (next to the existing strmiids).
+        # Idempotent: only matches the line that does not already contain mfplat.
+        sed -i 's/\(Qt5::WinMain -lstrmiids\) \(-mwindows\)/\1 -lmfplat -lmf -lmfreadwrite -lmfuuid \2/' \
+            "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/toonz/CMakeLists.txt" || return 1
     fi
 
     cd "$BUILD_PACKET_DIR/$PK_DIRNAME/thirdparty/tiff-4.0.3"
@@ -64,15 +130,34 @@ pkbuild() {
     if [ "$PLATFORM" = "linux" ]; then
         LOCAL_CFLAGS=" -fpermissive"
     fi
+    if [ "$PLATFORM" = "win" ]; then
+        # The OpenToonz sources rely on a few implicit downcasts (e.g.
+        # "TVectorImageP vi = img->cloneImage();" where cloneImage() returns
+        # TImage*). GCC rejects these as errors by default; the Linux build
+        # already relaxes them with -fpermissive. The cross (mingw) build needs
+        # the same relaxation, otherwise toonzlib fails with
+        # "invalid conversion from 'TImage*' to 'TVectorImage*'".
+        #
+        # -fcommon: GCC 10 defaults to -fno-common, which turns tentative
+        # definitions in headers (e.g. "double Avl_Dummy[];" in toonz4.6/avl.h,
+        # included by avl.c and tiio_plt.cpp) into multiple-definition link
+        # errors for the "image" library. Restore the pre-GCC10 -fcommon
+        # behaviour so these legacy globals collapse into one definition.
+        LOCAL_CFLAGS=" -fpermissive -fcommon"
+    fi
     
     if ! check_packet_function $NAME build.configure; then
-        if ! CFLAGS="$CFLAGS $LOCAL_CFLAGS" CXXFLAGS="$CXXFLAGS $LOCAL_CFLAGS" cmake \
+        if ! CFLAGS="$CFLAGS $LOCAL_CFLAGS" CXXFLAGS="$CXXFLAGS $LOCAL_CFLAGS" \
+              PKG_CONFIG_PATH="$ENVDEPS_PACKET_DIR/lib/pkgconfig:$PKG_CONFIG_PATH" \
+              cmake \
               -DCMAKE_PREFIX_PATH="$ENVDEPS_PACKET_DIR" \
               -DCMAKE_MODULE_PATH="$ENVDEPS_NATIVE_PACKET_DIR/share/cmake-3.6.2/Modules" \
               -DCMAKE_INSTALL_PREFIX="$INSTALL_PACKET_DIR" \
               -DPNG_PNG_INCLUDE_DIR="$ENVDEPS_PACKET_DIR/include" \
               -DPNG_LIBRARY="$ENVDEPS_PACKET_DIR/lib/$LOCAL_PNG_LIB" \
               -DGLUT_LIB="$ENVDEPS_PACKET_DIR/lib/$LOCAL_GLUT_LIB" \
+              -DSUPERLU_INCLUDE_DIR="$ENVDEPS_PACKET_DIR/include/superlu" \
+              -DSUPERLU_LIBRARY="$ENVDEPS_PACKET_DIR/lib/libsuperlu.a;$ENVDEPS_PACKET_DIR/lib/libblas.a" \
               $LOCAL_CMAKE_OPTIONS \
               $PK_CONFIGURE_OPTIONS \
               ../sources; \

--- a/env-builder-data/build/script/packet/opentoonz-master.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master.sh
@@ -39,6 +39,17 @@ pkbuild() {
         LOCAL_CMAKE_OPTIONS="$LOCAL_CMAKE_OPTIONS -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=FALSE"
         LOCAL_PNG_LIB="libpng16.dll.a"
         LOCAL_GLUT_LIB="libfreeglut.dll.a"
+
+        # On win64 the SSE2 path is enabled (USE_SSE2 = _WIN32 && x64). Inside
+        # the template rop_resample_rgbm_2<T> the line "TRaster32P rout32 = rout;"
+        # fails to compile when instantiated with T=TPixelRGBM64, because
+        # converting TRasterPT<TPixelRGBM64> to TRaster32P (TRasterPT<TPixelRGBM32>)
+        # would need two user-defined conversions. Route it through the generic
+        # TRasterP so it compiles for both instantiations (and yields a null
+        # raster for the 64-bit case, correctly skipping the 32-bit SSE2 path).
+        # Idempotent: the exact "= rout;" pattern no longer matches once patched.
+        sed -i 's/TRaster32P rout32 = rout;/TRaster32P rout32 = (TRasterP)rout;/' \
+            "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/common/trop/tresample.cpp" || return 1
     fi
 
     cd "$BUILD_PACKET_DIR/$PK_DIRNAME/thirdparty/tiff-4.0.3"

--- a/env-builder-data/build/script/packet/opentoonz-master.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master.sh
@@ -186,17 +186,21 @@ pkinstall() {
     if [ "$PLATFORM" = "win" ]; then
         local TARGET="$INSTALL_PACKET_DIR/bin/"
         
-        local LOCAL_DIR="/usr/local/$HOST/sys-root/$HOST/lib/"
-        cp "$LOCAL_DIR"/libgcc*.dll        "$TARGET" || return 1
-        cp "$LOCAL_DIR"/libstdc*.dll       "$TARGET" || return 1
-        cp "$LOCAL_DIR"/libquadmath*.dll   "$TARGET" || return 1
-        cp "$LOCAL_DIR"/libgfortran*.dll   "$TARGET" || return 1
+        # GCC runtime DLLs — Debian mingw-w64 layout (not the old Fedora
+        # /usr/local/HOST/sys-root layout the original script assumed).
+        local GCC_DIR="/usr/lib/gcc/$HOST/10-posix"
+        cp "$GCC_DIR"/libgcc_s_seh-1.dll   "$TARGET" || return 1
+        cp "$GCC_DIR"/libstdc++-6.dll      "$TARGET" || return 1
+        cp "$GCC_DIR"/libgfortran-5.dll    "$TARGET" || return 1
+        # libquadmath may not be present for all targets; ignore if absent.
+        cp "$GCC_DIR"/libquadmath*.dll     "$TARGET" 2>/dev/null || true
 
-        local LOCAL_DIR="/usr/local/$HOST/sys-root/bin/"
-        cp "$LOCAL_DIR"/libwinpthread*.dll "$TARGET" || return 1
-        cp "$LOCAL_DIR"/libgettextlib*.dll "$TARGET" || return 1
-        cp "$LOCAL_DIR"/libintl*.dll       "$TARGET" || return 1
-        cp "$LOCAL_DIR"/libiconv*.dll      "$TARGET" || return 1
+        local MINGW_DIR="/usr/$HOST"
+        cp "$MINGW_DIR/lib"/libwinpthread-1.dll "$TARGET" || return 1
+        cp "$MINGW_DIR/bin"/libintl-8.dll       "$TARGET" || return 1
+        cp "$MINGW_DIR/bin"/libiconv-2.dll      "$TARGET" || return 1
+        # libgettextlib may not ship as a standalone DLL; ignore if absent.
+        cp "$MINGW_DIR/bin"/libgettextlib*.dll  "$TARGET" 2>/dev/null || true
 
         # add icon
         cp "$BUILD_PACKET_DIR/$PK_DIRNAME/toonz/sources/toonz/toonz.ico" "$TARGET" || return 1

--- a/env-builder-data/build/script/packet/opentoonz-master.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master.sh
@@ -31,6 +31,12 @@ pkbuild() {
     fi
     if [ "$PLATFORM" = "win" ]; then
         LOCAL_CMAKE_OPTIONS="$LOCAL_CMAKE_OPTIONS -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=${HOST}-gcc -DCMAKE_CXX_COMPILER=${HOST}-g++"
+        # When cross-compiling for Windows, CMake's UNIX variable is false, so
+        # FindPkgConfig builds PKG_CONFIG_PATH from CMAKE_PREFIX_PATH using ';'
+        # separators and skips the ';'->':' conversion. pkg-config then sees a
+        # single invalid path and pkg_check_modules (liblzma, liblz4) fails.
+        # Disable that rewrite so the already-correct env PKG_CONFIG_PATH is used.
+        LOCAL_CMAKE_OPTIONS="$LOCAL_CMAKE_OPTIONS -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=FALSE"
         LOCAL_PNG_LIB="libpng16.dll.a"
         LOCAL_GLUT_LIB="libfreeglut.dll.a"
     fi

--- a/env-builder-data/build/script/packet/superlu-5.2.1.sh
+++ b/env-builder-data/build/script/packet/superlu-5.2.1.sh
@@ -1,8 +1,8 @@
 DEPS="blas-3.7.0"
 
-PK_DIRNAME="SuperLU_5.2.1"
-PK_ARCHIVE="superlu_5.2.1.tar.gz"
-PK_URL="http://crd-legacy.lbl.gov/~xiaoye/SuperLU/$PK_ARCHIVE"
+PK_DIRNAME="superlu-5.2.1"
+PK_ARCHIVE="v5.2.1.tar.gz"
+PK_URL="https://github.com/xiaoyeli/superlu/archive/$PK_ARCHIVE"
 
 source $INCLUDE_SCRIPT_DIR/inc-pkall-default.sh
 

--- a/env-builder-data/build/script/packet/superlu-5.2.1.sh
+++ b/env-builder-data/build/script/packet/superlu-5.2.1.sh
@@ -23,7 +23,7 @@ RANLIB       = ${RANLIB:-ranlib}
 CC           = ${CC:-gcc}
 CFLAGS       = -O3 -fPIC
 NOOPTS       = -fPIC
-FORTRAN      = ${FORTRAN:-gfortran}
+FORTRAN      = ${FORTRAN:-${FC:-gfortran}}
 FFLAGS       = -O2 -fPIC
 LOADER       = \$(CC)
 LOADOPTS     =
@@ -31,6 +31,13 @@ CDEFS        = -DAdd_
 EOF
 	
 	cp --remove-destination "$FILES_PACKET_DIR/mc64ad.c" "$BUILD_PACKET_DIR/$PK_DIRNAME/SRC/" || return 1
+	# Remove any stale object files / archives from a previous build so that
+	# 'make lib' actually recompiles the sources with the current compiler.
+	# Without this, a prior native (ELF) build leaves *.o behind and 'make lib'
+	# just re-archives the old ELF objects, producing a libsuperlu.a that the
+	# mingw linker cannot use (undefined references to intMalloc, etc.).
+	find "$BUILD_PACKET_DIR/$PK_DIRNAME" -name '*.o' -delete 2>/dev/null || true
+	rm -f "$BUILD_PACKET_DIR/$PK_DIRNAME/lib/"*.a 2>/dev/null || true
 	make lib || return 1
 }
 

--- a/env-builder-data/build/script/toolchain/win-common.sh
+++ b/env-builder-data/build/script/toolchain/win-common.sh
@@ -5,6 +5,19 @@
 export CROSS_TRIPLE="${TC_HOST}"
 export CROSS_ROOT="/usr/${CROSS_TRIPLE}"
 
+# Set CC, CXX, AR for cross-compilation. Needed for Makefile-based builds.
+export TC_CC="${CROSS_TRIPLE}-gcc"
+export TC_CXX="${CROSS_TRIPLE}-g++"
+export TC_AR="${CROSS_TRIPLE}-ar"
+export TC_RANLIB="${CROSS_TRIPLE}-ranlib"
+# Cross Fortran compiler. Needed so Makefile-based builds (e.g. superlu, blas)
+# produce Windows PE/COFF objects instead of native ELF. Without this, the
+# Fortran/C objects are ELF and the mingw linker silently fails to resolve
+# their symbols (e.g. undefined reference to intMalloc/superlu_malloc).
+export TC_FORTRAN="${CROSS_TRIPLE}-gfortran"
+export TC_FC="${CROSS_TRIPLE}-gfortran"
+export TC_F77="${CROSS_TRIPLE}-gfortran"
+
 #export TC_PATH="${CROSS_ROOT}/bin:$INITIAL_PATH"
 export TC_LD_LIBRARY_PATH="$CROSS_ROOT/lib:$INITIAL_LD_LIBRARY_PATH"
 

--- a/env-builder-data/build/script/toolchain/win-common.sh
+++ b/env-builder-data/build/script/toolchain/win-common.sh
@@ -33,7 +33,11 @@ unset TC_EXTRA_CPP_OPTIONS
 export TC_PKG_CONFIG_PATH=""
 #export TC_PKG_CONFIG_LIBDIR="$CROSS_ROOT/lib"
 #export TC_CMAKE_INCLUDE_PATH="${CROSS_ROOT}/include:$INITIAL_CMAKE_INCLUDE_PATH"
-#export TC_CMAKE_LIBRARY_PATH="${CROSS_ROOT}/lib:$INITIAL_CMAKE_LIBRARY_PATH"
+# Add the mingw sysroot lib dir to CMAKE_LIBRARY_PATH so find_library() can
+# locate the toolchain libraries (opengl32 -> GL_LIB, glu32 -> GLU_LIB,
+# pthread -> PTHREAD_LIBRARY) used by OpenToonz. Without this they resolve to
+# NOTFOUND and cmake configure fails.
+export TC_CMAKE_LIBRARY_PATH="${CROSS_ROOT}/lib:$INITIAL_CMAKE_LIBRARY_PATH"
 
 #export TC_ACLOCAL_PATH="/usr/share/aclocal"
 #if [ ! -z "$INITIAL_ACLOCAL_PATH" ]; then

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -11,12 +11,44 @@ publish() {
     local MASK="$4"
     local VERSION_FILE="$5"
 
-    local FILE=`ls "$FILEPATH/"$MASK`
-
     local VERSION=`cat "$VERSION_FILE" | cut -d'-' -f 1`
     local COMMIT=`cat "$VERSION_FILE" | cut -d'-' -f 2-`
     COMMIT="${COMMIT:0:5}"
     local DATE=`date -u +%Y.%m.%d`
+
+    shopt -s nullglob
+    local FILES=("$FILEPATH/"$MASK)
+    shopt -u nullglob
+
+    if [ ${#FILES[@]} -eq 0 ]; then
+        echo "Cannot find package files by mask '$MASK' in '$FILEPATH'. Cancel."
+        return 1
+    fi
+
+    local FILE=
+    if [ ${#FILES[@]} -eq 1 ]; then
+        FILE="${FILES[0]}"
+    else
+        local VERSION_MATCH=()
+        local FILE_BASE=
+        for FILE in "${FILES[@]}"; do
+            FILE_BASE=$(basename "$FILE")
+            if [[ "$FILE_BASE" == *"$VERSION"*"$COMMIT"* ]]; then
+                VERSION_MATCH+=("$FILE")
+            fi
+        done
+
+        if [ ${#VERSION_MATCH[@]} -eq 1 ]; then
+            FILE="${VERSION_MATCH[0]}"
+        elif [ ${#VERSION_MATCH[@]} -gt 1 ]; then
+            FILE=$(ls -t "${VERSION_MATCH[@]}" | head -n 1)
+            echo "Multiple package files match version/commit; using newest: $FILE"
+        else
+            FILE=$(ls -t "${FILES[@]}" | head -n 1)
+            echo "Multiple package files matched mask; using newest: $FILE"
+        fi
+    fi
+
     if [ -z "$COMMIT" ]; then
         echo "Cannot find version, pheraps package not ready. Cancel."
         return 1


### PR DESCRIPTION
A set of fixes to the build scripts so that the OpenToonz ME cross-build for Windows completes successfully and produces a working installer.

The win64 build failed at several stages: libraries were built in the wrong format, the code didn't compile with the mingw compiler, the NSIS installer crashed, and publishing picked the wrong file.

Cross-compiler: added gcc/gfortran variables.
lz4 and superlu: now built as static libraries in the correct format, so linking works without errors.
OpenToonz: small source and compiler-flag fixes for mingw (downcasts, Media Foundation, headers, etc.).
Runtime DLLs: fixed the copy paths for system DLLs to match the current Debian mingw layout.
NSIS installer: fixed crashes on non-ASCII paths and large folders, and fixed the LICENSE file colliding with the license folder on Windows.
Publishing: the script now correctly picks a single file when the mask matches several.