### PR TITLE
Fix version detection for OpenToonz Morevna Edition

### DIFF
--- a/env-builder-data/build/script/packet/opentoonz-master.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master.sh
@@ -17,7 +17,7 @@ pkhook_version() {
     local LOCAL_FILENAME="$PK_DIRNAME/toonz/sources/include/tversion.h"
     LANG=C LC_NUMERIC=C printf "%0.1f.%g\\n" \
       `cat "$LOCAL_FILENAME" | grep applicationVersion -m1 | cut -d "=" -f 2 | cut -d ";" -f 1 | cut -d "f" -f 1` \
-      `cat "$LOCAL_FILENAME" | grep applicationRevision -m1 | cut -d "=" -f 2 | cut -d ";" -f 1` \
+      `cat "$LOCAL_FILENAME" | grep applicationRevision -m1 | cut -d "=" -f 2 | cut -d ";" -f 1 | cut -d "f" -f 1` \
     || return 1
 }
 


### PR DESCRIPTION
The testing branch  OpenToonz Morevna Edition now declares applicationRevision = 1.0f (was 1) in tversion.h. The version hook stripped the f suffix only from applicationVersion, so printf got 1.0f and failed with "invalid number", stopping the build at the unpack step.