### PR TITLE
Fix opentoonz win32 build by matching any libgcc_s dll variant

### DIFF
--- a/env-builder-data/build/script/packet/opentoonz-master.sh
+++ b/env-builder-data/build/script/packet/opentoonz-master.sh
@@ -188,8 +188,9 @@ pkinstall() {
         
         # GCC runtime DLLs — Debian mingw-w64 layout (not the old Fedora
         # /usr/local/HOST/sys-root layout the original script assumed).
+        # libgcc_s variant differs by arch: i686=dw2, x86_64=seh — use a glob.
         local GCC_DIR="/usr/lib/gcc/$HOST/10-posix"
-        cp "$GCC_DIR"/libgcc_s_seh-1.dll   "$TARGET" || return 1
+        cp "$GCC_DIR"/libgcc_s_*-1.dll     "$TARGET" || return 1
         cp "$GCC_DIR"/libstdc++-6.dll      "$TARGET" || return 1
         cp "$GCC_DIR"/libgfortran-5.dll    "$TARGET" || return 1
         # libquadmath may not be present for all targets; ignore if absent.


### PR DESCRIPTION
The win32 build failed during the install step:
cp: cannot stat '/usr/lib/gcc/i686-w64-mingw32/10-posix/libgcc_s_seh-1.dll': No such file or directory

libgcc_s_seh-1.dll exists only for x86_64; the i686 runtime DLL in Debian mingw-w64 is libgcc_s_dw2-1.dll (dwarf-2 exception model).